### PR TITLE
Updated README for 3D cases for T-Beam.

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -62,8 +62,11 @@ sure to buy the frequency range which is legal for your country.  For the USA, y
 
 Instructions for installing prebuilt firmware can be found [here](https://github.com/meshtastic/Meshtastic-esp32/blob/master/README.md).
 
-For a nice TTGO 3D printable case see this [design](https://www.thingiverse.com/thing:3773717) by [bsiege](https://www.thingiverse.com/bsiege).
-For a nice Heltec 3D printable case see this [design](https://www.thingiverse.com/thing:3125854) by [ornotermes](https://www.thingiverse.com/ornotermes).
+For a nice printable cases:
+
+1. TTGO T-Beam V0 see this [design](https://www.thingiverse.com/thing:3773717) by [bsiege](https://www.thingiverse.com/bsiege).
+2. TTGO T_Beam V1 see this [design](https://www.thingiverse.com/thing:3830711) by [rwanrooy](https://www.thingiverse.com/rwanrooy) or this [remix](https://www.thingiverse.com/thing:3949330) by [8ung](https://www.thingiverse.com/8ung)
+3. Heltec Lora32 see this [design](https://www.thingiverse.com/thing:3125854) by [ornotermes](https://www.thingiverse.com/ornotermes).
 
 # Disclaimers
 


### PR DESCRIPTION
T-Beam V1 has moved the antenna connector a bit to the right compared
to the V0. This makes the case not fit.
Added 2 more links for T-Beam cases.