### PR TITLE
#13 - add support for 433MHz Heltec boards

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Prebuilt binaries for the supported radios is available in our [releases](https:
 
 The instructions currently require a few commmand lines, but it should be pretty straightforward.  Please post comments on our group chat if you have problems or successes.  Steps to install:
 
-1. Purchase a radio (see above) with the correct frequencies for your country (915MHz for US or JP, 470MHz for CN, 870MHz for EU).
+1. Purchase a radio (see above) with the correct frequencies for your country (915MHz for US or JP, 470MHz for CN, 433MHz and 870MHz for EU).
 2. Install "pip".  Pip is the python package manager we use to get the esptool installer app.  Instructions [here](https://www.makeuseof.com/tag/install-pip-for-python/).
 3. Run "pip install --upgrade esptool" to get esptool installed on your machine
 4. Connect your radio to your USB port

--- a/bin/build-all.sh
+++ b/bin/build-all.sh
@@ -4,7 +4,7 @@ set -e
 
 source bin/version.sh
 
-COUNTRIES="US EU CN JP"
+COUNTRIES="US EU433 EU865 CN JP"
 # COUNTRIES=US
 
 SRCMAP=.pio/build/esp32/output.map

--- a/docs/radio-settings.md
+++ b/docs/radio-settings.md
@@ -10,6 +10,13 @@ See [this site](https://www.rfwireless-world.com/Tutorials/LoRa-channels-list.ht
 
 The maximum power allowed is +14dBM.
 
+### 433 MHz
+
+There are eight channels defined with a 0.2 MHz gap between them.
+Channel zero starts at 433.175 MHz
+
+### 870 MHz
+
 There are eight channels defined with a 0.3 MHz gap between them.
 Channel zero starts at 865.20 MHz
 

--- a/src/MeshRadio.h
+++ b/src/MeshRadio.h
@@ -13,10 +13,15 @@
 #define CH_SPACING_US   2.16f // MHz
 #define NUM_CHANNELS_US 13
 
-// EU channel settings
-#define CH0_EU          865.2f // MHz
-#define CH_SPACING_EU   0.3f // MHz
-#define NUM_CHANNELS_EU 10
+// EU433 channel settings
+#define CH0_EU433          433.175f // MHz
+#define CH_SPACING_EU433   0.2f // MHz
+#define NUM_CHANNELS_EU433 8
+
+// EU865 channel settings
+#define CH0_EU865          865.2f // MHz
+#define CH_SPACING_EU865   0.3f // MHz
+#define NUM_CHANNELS_EU865 10
 
 // CN channel settings
 #define CH0_CN          470.0f // MHz
@@ -33,10 +38,14 @@
 #define CH0 CH0_US
 #define CH_SPACING CH_SPACING_US
 #define NUM_CHANNELS NUM_CHANNELS_US
-#elif defined(HW_VERSION_EU)
-#define CH0 CH0_EU
-#define CH_SPACING CH_SPACING_EU
-#define NUM_CHANNELS NUM_CHANNELS_EU
+#elif defined(HW_VERSION_EU433)
+#define CH0 CH0_EU433
+#define CH_SPACING CH_SPACING_EU433
+#define NUM_CHANNELS NUM_CHANNELS_EU433
+#elif defined(HW_VERSION_EU865)
+#define CH0 CH0_EU865
+#define CH_SPACING CH_SPACING_EU865
+#define NUM_CHANNELS NUM_CHANNELS_EU865
 #elif defined(HW_VERSION_CN)
 #define CH0 CH0_CN
 #define CH_SPACING CH_SPACING_CN


### PR DESCRIPTION
Added in support for the Heltec 433MHz model. Successfully builds, able to pair with mobile device and  able to communicate with a second version of the same model, paired with a different phone. 