### PR TITLE
set has_gps flag after decoding the first GPS message

### DIFF
--- a/src/GPS.cpp
+++ b/src/GPS.cpp
@@ -3,6 +3,7 @@
 #include "time.h"
 #include <sys/time.h>
 #include "configuration.h"
+#include "NodeDB.h"
 
 // stuff that really should be in in the instance instead...
 HardwareSerial _serial_gps(GPS_SERIAL_NUM);
@@ -98,8 +99,16 @@ void GPS::doTask()
 
     while (_serial_gps.available())
     {
-        encode(_serial_gps.read());
-        // DEBUG_MSG("Got GPS response\n");
+        if (encode(_serial_gps.read()))
+        {
+            if (!myNodeInfo.has_gps)
+            {
+                // We successfully decoded a GPS message. Set the flag so that
+                // phone doesn't have to do GPS stuff.
+                DEBUG_MSG("Saw first GPS response\n");
+                myNodeInfo.has_gps = true;
+            }
+        }
     }
 
     if (!timeSetFromGPS && time.isValid() && date.isValid())

--- a/src/NodeDB.cpp
+++ b/src/NodeDB.cpp
@@ -68,10 +68,6 @@ void NodeDB::init()
     radioConfig.preferences.ls_secs = 60 * 60;
     radioConfig.preferences.phone_timeout_secs = 15 * 60;
 
-#ifdef GPS_RX_PIN
-    // some hardware defaults to have a built in GPS
-    myNodeInfo.has_gps = true;
-#endif
     strncpy(myNodeInfo.region, xstr(HW_VERSION), sizeof(myNodeInfo.region));
     strncpy(myNodeInfo.firmware_version, xstr(APP_VERSION), sizeof(myNodeInfo.firmware_version));
     strncpy(myNodeInfo.hw_model, HW_VENDOR, sizeof(myNodeInfo.hw_model));


### PR DESCRIPTION
Fixes #11.

Tested:

Flashed to TTGO T-BEAM, reset it while watching serial output. Saw `Saw
first GPS response`. Also, seeing "GPS" on the screen.