### PR TITLE
add a Lock, LockGuard and printThreadInfo

### DIFF
--- a/src/debug.cpp
+++ b/src/debug.cpp
@@ -1,0 +1,20 @@
+#include "debug.h"
+
+#include <cstdint>
+
+#include <freertos/FreeRTOS.h>
+#include <freertos/task.h>
+
+#include "configuration.h"
+
+namespace meshtastic
+{
+
+void printThreadInfo(const char *extra)
+{
+    uint32_t taskHandle = reinterpret_cast<uint32_t>(xTaskGetCurrentTaskHandle());
+    DEBUG_MSG("printThreadInfo(%s) task: %" PRIx32 " core id: %u min free stack: %u\n", extra, taskHandle, xPortGetCoreID(),
+              uxTaskGetStackHighWaterMark(nullptr));
+}
+
+} // namespace meshtastic

--- a/src/debug.h
+++ b/src/debug.h
@@ -1,0 +1,10 @@
+#pragma once
+
+namespace meshtastic
+{
+
+/// Dumps out which core we are running on, and min level of remaining stack
+/// seen.
+void printThreadInfo(const char *extra);
+
+} // namespace meshtastic

--- a/src/lock.cpp
+++ b/src/lock.cpp
@@ -1,0 +1,35 @@
+#include "lock.h"
+
+#include <cassert>
+
+namespace meshtastic
+{
+
+Lock::Lock()
+{
+    handle = xSemaphoreCreateBinary();
+    assert(handle);
+    assert(xSemaphoreGive(handle));
+}
+
+void Lock::lock()
+{
+    assert(xSemaphoreTake(handle, portMAX_DELAY));
+}
+
+void Lock::unlock()
+{
+    assert(xSemaphoreGive(handle));
+}
+
+LockGuard::LockGuard(Lock *lock) : lock(lock)
+{
+    lock->lock();
+}
+
+LockGuard::~LockGuard()
+{
+    lock->unlock();
+}
+
+} // namespace meshtastic

--- a/src/lock.h
+++ b/src/lock.h
@@ -1,0 +1,47 @@
+#pragma once
+
+#include <FreeRTOS/FreeRTOS.h>
+#include <FreeRTOS/semphr.h>
+
+namespace meshtastic
+{
+
+// Simple wrapper around FreeRTOS API for implementing a mutex lock.
+class Lock
+{
+  public:
+    Lock();
+
+    Lock(const Lock&) = delete;
+    Lock& operator=(const Lock&) = delete;
+
+    /// Locks the lock.
+    //
+    // Must not be called from an ISR.
+    void lock();
+
+    // Unlocks the lock.
+    //
+    // Must not be called from an ISR.
+    void unlock();
+
+  private:
+    SemaphoreHandle_t handle;
+};
+
+// RAII lock guard.
+class LockGuard
+{
+  public:
+    LockGuard(Lock *lock);
+    ~LockGuard();
+
+    LockGuard(const LockGuard&) = delete;
+    LockGuard& operator=(const LockGuard&) = delete;
+
+  private:
+    Lock* lock;
+};
+
+
+} // namespace meshtastic


### PR DESCRIPTION
* `Lock`: trivial wrapper for FreeRTOS binary semaphores
* `LockGuard`: RAII wrapper for using `Lock`
* `printThreadInfo`: helper for showing which core/FreeRTOS task we are
  running under