### PR TITLE
underp include paths in lock.h

### DIFF
--- a/src/lock.h
+++ b/src/lock.h
@@ -1,7 +1,7 @@
 #pragma once
 
-#include <FreeRTOS/FreeRTOS.h>
-#include <FreeRTOS/semphr.h>
+#include <freertos/FreeRTOS.h>
+#include <freertos/semphr.h>
 
 namespace meshtastic
 {


### PR DESCRIPTION
Had the casing wrong, but could get away with it on a mac.