### PR TITLE
fix #52: bluetooth not pairing

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -260,7 +260,7 @@ void initBluetooth()
 
     // Note: these callbacks might be coming in from a different thread.
     BLEServer *serve = initBLE(
-        [](uint8_t pin) {
+        [](uint32_t pin) {
             powerFSM.trigger(EVENT_BLUETOOTH_PAIR);
             screen.startBluetoothPinScreen(pin);
         },


### PR DESCRIPTION
Silly type error on my part - PIN was always truncated to lower 8 bits.
:grimacing:

Tested: Pairing now works from both nRF Connect and phone.