### PR TITLE
Increase screen timeout to 5 minutes

### DIFF
--- a/src/NodeDB.cpp
+++ b/src/NodeDB.cpp
@@ -55,7 +55,7 @@ void NodeDB::resetRadioConfig()
         radioConfig.preferences.send_owner_interval = 4; // per sw-design.md
         radioConfig.preferences.position_broadcast_secs = 15 * 60;
         radioConfig.preferences.wait_bluetooth_secs = 120;
-        radioConfig.preferences.screen_on_secs = 30;
+        radioConfig.preferences.screen_on_secs = 5 * 60;
         radioConfig.preferences.mesh_sds_timeout_secs = 2 * 60 * 60;
         radioConfig.preferences.phone_sds_timeout_sec = 2 * 60 * 60;
         radioConfig.preferences.sds_secs = 365 * 24 * 60 * 60; // one year


### PR DESCRIPTION
Fixes issue #80. Measured current drawn by oled display is very tiny. Screen-on time can be increased with no significant effect on battery life.