### PR TITLE
0.4.3 Fix #92: omg - for the last couple of weeks the official builds…

### DIFF
--- a/bin/build-all.sh
+++ b/bin/build-all.sh
@@ -6,6 +6,10 @@ source bin/version.sh
 
 COUNTRIES="US EU433 EU865 CN JP"
 #COUNTRIES=US
+#COUNTRIES=CN
+
+BOARDS="ttgo-lora32-v2 ttgo-lora32-v1 tbeam heltec"
+#BOARDS=tbeam
 
 OUTDIR=release/latest
 
@@ -24,23 +28,21 @@ function do_build {
     SRCBIN=.pio/build/$ENV_NAME/firmware.bin
     SRCELF=.pio/build/$ENV_NAME/firmware.elf
     rm -f $SRCBIN 
-    pio run --environment $ENV_NAME # -v
+
+    # The shell vars the build tool expects to find
+    export HW_VERSION="1.0-$COUNTRY"
+    export APP_VERSION=$VERSION
+    export COUNTRY
+
+    pio run --jobs 4 --environment $ENV_NAME # -v
     cp $SRCBIN $OUTDIR/bins/firmware-$ENV_NAME-$COUNTRY-$VERSION.bin
     cp $SRCELF $OUTDIR/elfs/firmware-$ENV_NAME-$COUNTRY-$VERSION.elf
 }
 
 for COUNTRY in $COUNTRIES; do 
-
-    HWVERSTR="1.0-$COUNTRY"
-    COMMONOPTS="-DAPP_VERSION=$VERSION -DHW_VERSION_$COUNTRY -DHW_VERSION=$HWVERSTR -Wall -Wextra -Wno-missing-field-initializers -Isrc -Os -DAXP_DEBUG_PORT=Serial"
-
-    export PLATFORMIO_BUILD_FLAGS="$COMMONOPTS"
-
-    #do_build "tbeam0.7"
-    do_build "ttgo-lora32-v2"
-    do_build "ttgo-lora32-v1"
-    do_build "tbeam"
-    do_build "heltec"
+    for BOARD in $BOARDS; do
+        do_build $BOARD
+    done
 done
 
 # keep the bins in archive also

--- a/bin/version.sh
+++ b/bin/version.sh
@@ -1,3 +1,3 @@
 
 
-export VERSION=0.4.2
+export VERSION=0.4.3

--- a/platformio.ini
+++ b/platformio.ini
@@ -12,9 +12,14 @@
 default_envs = tbeam
 
 [common]
-; default to a US frequency range, change it as needed for your region and hardware (CN, JP, EU433, EU865)
-hw_version = US
+; common is not currently used
 
+; REQUIRED environment variables - if not set the specified default will be sued
+; The following environment variables must be set in the shell if you'd like to override them.
+; They are used in this ini file as systenv.VARNAME, so in your shell do export "VARNAME=fish"
+; HW_VERSION (default US)
+; APP_VERSION (default emptystring)
+; HW_VERSION (default emptystring)
 
 [env]
 platform = espressif32
@@ -26,7 +31,11 @@ board_build.partitions = partition-table.csv
 
 ; note: we add src to our include search path so that lmic_project_config can override
 ; FIXME: fix lib/BluetoothOTA dependency back on src/ so we can remove -Isrc
-build_flags = -Wno-missing-field-initializers -Isrc -Isrc/rf95 -Os -Wl,-Map,.pio/build/output.map -DAXP_DEBUG_PORT=Serial -DHW_VERSION_${common.hw_version}
+build_flags = -Wno-missing-field-initializers -Isrc -Isrc/rf95 -Os -Wl,-Map,.pio/build/output.map 
+  -DAXP_DEBUG_PORT=Serial 
+  -DHW_VERSION_${sysenv.COUNTRY}
+  -DAPP_VERSION=${sysenv.APP_VERSION}
+  -DHW_VERSION=${sysenv.HW_VERSION}
 
 ; not needed included in ttgo-t-beam board file
 ; also to use PSRAM https://docs.platformio.org/en/latest/platforms/espressif32.html#external-ram-psram

--- a/src/MeshRadio.h
+++ b/src/MeshRadio.h
@@ -55,7 +55,10 @@
 #define CH_SPACING CH_SPACING_JP
 #define NUM_CHANNELS NUM_CHANNELS_JP
 #else
-#error "HW_VERSION not set"
+// HW version not set - assume US
+#define CH0 CH0_US
+#define CH_SPACING CH_SPACING_US
+#define NUM_CHANNELS NUM_CHANNELS_US
 #endif
 
 /**

--- a/src/configuration.h
+++ b/src/configuration.h
@@ -31,8 +31,9 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 // If app version is not specified we assume we are not being invoked by the build script
 #ifndef APP_VERSION
-#define APP_VERSION 0.0.0   // this def normally comes from build-all.sh
-#define HW_VERSION 1.0 - US // normally comes from build-all.sh and contains the region code
+#error APP_VERSION, HW_VERSION, and HW_VERSION_countryname must be set by the build environment
+//#define APP_VERSION 0.0.0   // this def normally comes from build-all.sh
+//#define HW_VERSION 1.0 - US // normally comes from build-all.sh and contains the region code
 #endif
 
 // -----------------------------------------------------------------------------


### PR DESCRIPTION
… were

all using US frequencies.  This build fixes this (and makes the build
system cleaner in general).

If you are building your own builds in the IDE you'll need to start
setting an environment variable called COUNTRY to your two letter
country code (or leave unset to get US frequencies).  See new comment
in platformio.ini.